### PR TITLE
Add timeout argument to call_loop_with_reconnect_with_readonly

### DIFF
--- a/lib/redis/reconnect_with_readonly.rb
+++ b/lib/redis/reconnect_with_readonly.rb
@@ -55,7 +55,7 @@ class Redis
       end
     end
 
-    def call_loop_with_reconnect_with_readonly(command, timeout, &block)
+    def call_loop_with_reconnect_with_readonly(command, timeout = 0, &block)
       ReconnectWithReadonly.reconnect_with_readonly(self) do
         call_loop_without_reconnect_with_readonly(command, timeout, &block)
       end

--- a/lib/redis/reconnect_with_readonly.rb
+++ b/lib/redis/reconnect_with_readonly.rb
@@ -55,9 +55,9 @@ class Redis
       end
     end
 
-    def call_loop_with_reconnect_with_readonly(command, &block)
+    def call_loop_with_reconnect_with_readonly(command, timeout, &block)
       ReconnectWithReadonly.reconnect_with_readonly(self) do
-        call_loop_without_reconnect_with_readonly(command, &block)
+        call_loop_without_reconnect_with_readonly(command, timeout, &block)
       end
     end
 

--- a/redis-reconnect_with_readonly.gemspec
+++ b/redis-reconnect_with_readonly.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "redis"
+  spec.add_dependency "redis", ">= 3.3.0"
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
The redis-rb gem's `call_loop` def (seen here https://github.com/redis/redis-rb/commit/65f8886078e8b726dd78353edc99b5a5fd6a97c0#diff-597c124889a64c18744b52ef9687c572R130) accepts an optional `timeout` argument. Since it's optional, this gem does not necessarily need to submit timeout argument when it calls `call_loop_without_reconnect_with_readonly` (though doing so is polite).

The bigger issue is that when a redis subscription is created, that subscription then uses `call_loop` with the new timeout value. It submits two arguments where `call_loop_with_reconnect_with_readonly` only expects one and we stack trace with

    ArgumentError: wrong number of arguments (given 2, expected 1)
    /usr/local/bundle/gems/redis-reconnect_with_readonly-0.9.3/lib/redis/reconnect_with_readonly.rb:58:in `call_loop_with_reconnect_with_readonly'

This change adds the `timeout` argument to `call_loop_with_reconnect_with_readonly` which should fix the issue if I've done my research.

(Caveat: we've yet to meaningfully test this, but I'm opening up a PR now to at least get some additional eyes on it.)